### PR TITLE
Improve Cloud Run compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim
 
 ENV RUN_HOST="0.0.0.0"
-ENV RUN_PORT=80
+ENV RUN_PORT=8080
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
@@ -12,6 +12,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-EXPOSE 80
+EXPOSE 8080
 
 CMD ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -68,3 +68,8 @@ backend:
 With your virtual environment activated run the server as follows
 
 `python main.py`
+
+### Google Cloud Run
+When deploying to Cloud Run the container must listen on the port provided in
+the `PORT` environment variable. The default configuration already uses this
+value if present, and the Dockerfile exposes port `8080`.

--- a/main.py
+++ b/main.py
@@ -84,9 +84,6 @@ if __name__ == "__main__":
         run_config = {'ssl_context': 'adhoc'}
     app.secret_key = secrets.token_hex(24)
 
-    app.run(
-            host=os.environ.get('RUN_HOST', '127.0.0.1'),
-            port=int(os.environ.get('RUN_PORT', 5000)),
-            debug=True,
-            **run_config
-            )
+    host = os.environ.get("RUN_HOST", "127.0.0.1")
+    port = int(os.environ.get("PORT", os.environ.get("RUN_PORT", 5000)))
+    app.run(host=host, port=port, debug=True, **run_config)


### PR DESCRIPTION
## Summary
- default to Cloud Run port if available
- expose port 8080 in Dockerfile
- mention Cloud Run behaviour in README

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_685f9052d548832d9dd6bbe743fc7622