### PR TITLE
Fix Cloud Run port defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,4 +72,5 @@ With your virtual environment activated run the server as follows
 ### Google Cloud Run
 When deploying to Cloud Run the container must listen on the port provided in
 the `PORT` environment variable. The default configuration already uses this
-value if present, and the Dockerfile exposes port `8080`.
+value if present and otherwise falls back to port `8080`. The Dockerfile also
+exposes port `8080`.

--- a/main.py
+++ b/main.py
@@ -84,6 +84,6 @@ if __name__ == "__main__":
         run_config = {'ssl_context': 'adhoc'}
     app.secret_key = secrets.token_hex(24)
 
-    host = os.environ.get("RUN_HOST", "127.0.0.1")
-    port = int(os.environ.get("PORT", os.environ.get("RUN_PORT", 5000)))
+    host = os.environ.get("RUN_HOST", "0.0.0.0")
+    port = int(os.environ.get("PORT", os.environ.get("RUN_PORT", 8080)))
     app.run(host=host, port=port, debug=True, **run_config)


### PR DESCRIPTION
## Summary
- default host to `0.0.0.0` and port to `8080`
- document the Cloud Run port fallback

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_685f981b4e40832dbd7f7af53e836c19